### PR TITLE
 Add development script, refactor Kimi adapter, and polish UI details

### DIFF
--- a/AI_ChatApp.swift
+++ b/AI_ChatApp.swift
@@ -5,8 +5,8 @@
 //  Created by Lasse Vestergaard on 10/02/2026.
 //
 
-import SwiftUI
 import AppKit
+import SwiftUI
 
 extension Notification.Name {
     static let openSettingsRequested = Notification.Name("openSettingsRequested")
@@ -85,7 +85,8 @@ private struct ForceQuitShortcutModifier: ViewModifier {
                 if monitor != nil { return }
                 monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
                     guard event.modifierFlags.contains(.command),
-                          let key = event.charactersIgnoringModifiers?.lowercased() else {
+                        let key = event.charactersIgnoringModifiers?.lowercased()
+                    else {
                         return event
                     }
 
@@ -110,8 +111,8 @@ private struct ForceQuitShortcutModifier: ViewModifier {
     }
 }
 
-private extension View {
-    func forceQuitShortcut() -> some View {
+extension View {
+    fileprivate func forceQuitShortcut() -> some View {
         modifier(ForceQuitShortcutModifier())
     }
 }

--- a/Models/LLMModels.swift
+++ b/Models/LLMModels.swift
@@ -6,7 +6,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Hashable {
     case openRouter = "OpenRouter"
     case vercelAI = "Vercel AI"
     case gemini = "Gemini"
-    case kimi = "Kimi"
+    case kimi = "Kimi for Coding"
     case ollama = "Ollama"
     case claudeCode = "Claude Code"
     case openAICodex = "OpenAI Codex"
@@ -57,10 +57,13 @@ struct ToolCallInfo: Hashable {
     let id: String
     let name: String
     let arguments: String  // JSON string of arguments
-    let serverName: String // MCP server that owns this tool
+    let serverName: String  // MCP server that owns this tool
     let thoughtSignature: String?
 
-    init(id: String, name: String, arguments: String, serverName: String, thoughtSignature: String? = nil) {
+    init(
+        id: String, name: String, arguments: String, serverName: String,
+        thoughtSignature: String? = nil
+    ) {
         self.id = id
         self.name = name
         self.arguments = arguments
@@ -81,10 +84,13 @@ struct LLMChatMessage: Hashable {
     let role: ChatRole
     let content: String
     let attachments: [Attachment]
-    let toolCalls: [ToolCallInfo]    // Non-empty when assistant requests tool calls
+    let toolCalls: [ToolCallInfo]  // Non-empty when assistant requests tool calls
     let toolResult: ToolResultInfo?  // Non-nil when role == .tool
 
-    init(role: ChatRole, content: String, attachments: [Attachment] = [], toolCalls: [ToolCallInfo] = [], toolResult: ToolResultInfo? = nil) {
+    init(
+        role: ChatRole, content: String, attachments: [Attachment] = [],
+        toolCalls: [ToolCallInfo] = [], toolResult: ToolResultInfo? = nil
+    ) {
         self.role = role
         self.content = content
         self.attachments = attachments

--- a/Views/ChatSidebar.swift
+++ b/Views/ChatSidebar.swift
@@ -16,7 +16,7 @@ struct ThreadRow: View {
             if let lastMessage = thread.messages.last {
                 Text(lastMessage.text)
                     .font(.system(size: 11))
-                    .foregroundStyle(theme.textSecondary)
+                    .foregroundStyle(theme.textPrimary.opacity(0.72))
                     .lineLimit(1)
             }
         }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -156,16 +156,7 @@ struct ContentView: View {
     private var mainView: some View { buildMainView() }
 
     private func buildMainView() -> AnyView {
-        let base = splitView.toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    createThread()
-                } label: {
-                    Image(systemName: "square.and.pencil")
-                }
-                .help("New Chat")
-            }
-        }
+        let base = splitView
 
         let dialogs = base
             .sheet(isPresented: $isShowingSettings) { settingsSheet }
@@ -301,6 +292,27 @@ struct ContentView: View {
         VStack(spacing: 0) {
             ScrollView {
                 LazyVStack(spacing: 2) {
+                    HStack(spacing: 8) {
+                        Text("Chats")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(theme.textSecondary)
+
+                        Spacer()
+
+                        Button {
+                            createThread()
+                        } label: {
+                            Label("New", systemImage: "square.and.pencil")
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(theme.textSecondary)
+                        .help("New Chat")
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.top, 4)
+                    .padding(.bottom, 6)
+
                     ForEach(filteredThreads) { thread in
                         let isSelected = thread.id == selectedThreadID
                         Button {
@@ -391,10 +403,19 @@ struct ContentView: View {
         VStack(spacing: 0) {
             if currentMessages.isEmpty {
                 Spacer()
-                VStack(spacing: 16) {
+                VStack(spacing: 10) {
                     Image(systemName: "quote.bubble")
                         .font(.system(size: 48, weight: .thin))
                         .foregroundStyle(theme.textTertiary)
+
+                    Text("Start a conversation")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(theme.textSecondary)
+
+                    Text("Choose a chat in the sidebar or write a message below.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(theme.textTertiary)
+
                     if statusMessage != nil {
                         Text(statusMessage!)
                             .font(.caption)
@@ -2077,10 +2098,6 @@ struct ContentView: View {
                         .font(.system(size: 11, design: .monospaced))
                         .foregroundStyle(theme.textTertiary)
                         .lineLimit(1)
-
-                    Text(formatTimestamp(entry.timestamp))
-                        .font(.system(size: 10))
-                        .foregroundStyle(theme.textTertiary)
                 }
             }
 
@@ -2139,12 +2156,6 @@ struct ContentView: View {
         default:
             return .purple
         }
-    }
-
-    private func formatTimestamp(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss"
-        return formatter.string(from: date)
     }
 
     private func revertEntry(_ entry: UndoEntry) {

--- a/Views/MarkdownView.swift
+++ b/Views/MarkdownView.swift
@@ -16,9 +16,10 @@ struct MarkdownView: View {
     }
 
     var body: some View {
+        let blocks = parseBlocks(source)
         VStack(alignment: .leading, spacing: 12) {
-            ForEach(Array(parseBlocks(source).enumerated()), id: \.offset) { idx, block in
-                renderBlock(block, isLast: idx == parseBlocks(source).count - 1)
+            ForEach(Array(blocks.enumerated()), id: \.offset) { idx, block in
+                renderBlock(block, isLast: idx == blocks.count - 1)
             }
         }
     }
@@ -28,6 +29,7 @@ struct MarkdownView: View {
     private enum Block {
         case heading(level: Int, text: String)
         case codeBlock(language: String?, code: String, closed: Bool)
+        case table(headers: [String], rows: [[String]])
         case unorderedList(items: [String])
         case orderedList(items: [String])
         case paragraph(text: String)
@@ -82,6 +84,13 @@ struct MarkdownView: View {
                 continue
             }
 
+            // Markdown table
+            if let table = parseTable(lines: lines, index: i) {
+                blocks.append(.table(headers: table.headers, rows: table.rows))
+                i = table.nextIndex
+                continue
+            }
+
             // Unordered list
             if isUnorderedListItem(line) {
                 var items: [String] = []
@@ -116,7 +125,8 @@ struct MarkdownView: View {
                 let l = lines[i]
                 let lt = l.trimmingCharacters(in: .whitespaces)
                 if lt.isEmpty || l.hasPrefix("```") || parseHeading(l) != nil
-                    || isUnorderedListItem(l) || isOrderedListItem(l) {
+                    || isUnorderedListItem(l) || isOrderedListItem(l)
+                    || parseTable(lines: lines, index: i) != nil {
                     break
                 }
                 paraLines.append(l)
@@ -172,6 +182,89 @@ struct MarkdownView: View {
         return String(t[t.index(afterDot, offsetBy: 1)...])
     }
 
+    private func parseTable(lines: [String], index: Int) -> (headers: [String], rows: [[String]], nextIndex: Int)? {
+        guard index + 1 < lines.count else { return nil }
+
+        let headerLine = lines[index]
+        let separatorLine = lines[index + 1]
+
+        guard isTableRowLine(headerLine), isTableSeparatorLine(separatorLine) else {
+            return nil
+        }
+
+        let headers = parseTableCells(headerLine)
+        guard headers.count >= 2 else { return nil }
+
+        var rows: [[String]] = []
+        var i = index + 2
+        while i < lines.count {
+            let rowLine = lines[i]
+            if rowLine.trimmingCharacters(in: .whitespaces).isEmpty || !isTableRowLine(rowLine) {
+                break
+            }
+
+            var cells = parseTableCells(rowLine)
+            if cells.count < headers.count {
+                cells += Array(repeating: "", count: headers.count - cells.count)
+            } else if cells.count > headers.count {
+                cells = Array(cells.prefix(headers.count))
+            }
+            rows.append(cells)
+            i += 1
+        }
+
+        return (headers: headers, rows: rows, nextIndex: i)
+    }
+
+    private func isTableRowLine(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.contains("|") else { return false }
+        let cells = parseTableCells(trimmed)
+        return cells.count >= 2
+    }
+
+    private func isTableSeparatorLine(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.contains("|") else { return false }
+
+        let parts = trimmed.split(separator: "|", omittingEmptySubsequences: false)
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        guard parts.count >= 2 else { return false }
+
+        return parts.allSatisfy { part in
+            guard part.allSatisfy({ $0 == "-" || $0 == ":" }) else { return false }
+            let dashCount = part.filter { $0 == "-" }.count
+            return dashCount >= 3
+        }
+    }
+
+    private func parseTableCells(_ line: String) -> [String] {
+        var trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("|") {
+            trimmed.removeFirst()
+        }
+        if trimmed.hasSuffix("|") {
+            trimmed.removeLast()
+        }
+        var cells = trimmed
+            .split(separator: "|", omittingEmptySubsequences: false)
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+
+        // Some model outputs include an extra trailing pipe (e.g. "||") which
+        // becomes a phantom empty column. Trim only outer empty cells so we keep
+        // intentional empty cells inside the table.
+        while cells.first == "" {
+            cells.removeFirst()
+        }
+        while cells.last == "" {
+            cells.removeLast()
+        }
+
+        return cells
+    }
+
     // MARK: - Rendering
 
     @ViewBuilder
@@ -182,6 +275,9 @@ struct MarkdownView: View {
 
         case .codeBlock(let language, let code, let closed):
             CodeBlockView(language: language, code: code, closed: closed, showCursor: isStreaming && isLast && !closed)
+
+        case .table(let headers, let rows):
+            tableView(headers: headers, rows: rows)
 
         case .unorderedList(let items):
             VStack(alignment: .leading, spacing: 6) {
@@ -216,6 +312,54 @@ struct MarkdownView: View {
             theme.divider.frame(height: 1)
                 .padding(.vertical, 4)
         }
+    }
+
+    @ViewBuilder
+    private func tableView(headers: [String], rows: [[String]]) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
+                GridRow {
+                    ForEach(Array(headers.enumerated()), id: \.offset) { _, cell in
+                        tableCell(cell, isHeader: true)
+                    }
+                }
+
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                    GridRow {
+                        ForEach(Array(row.enumerated()), id: \.offset) { _, cell in
+                            tableCell(cell, isHeader: false)
+                        }
+                    }
+                }
+            }
+        }
+        .background(theme.codeBackground, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(theme.codeBorder, lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func tableCell(_ text: String, isHeader: Bool) -> some View {
+        inlineMarkdown(text.isEmpty ? " " : text)
+            .font(isHeader ? .system(size: 13, weight: .semibold) : .system(size: 13))
+            .frame(minWidth: 120, maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(isHeader ? theme.codeHeaderBackground.opacity(0.6) : Color.clear)
+            .overlay(
+                Rectangle()
+                    .fill(theme.codeBorder.opacity(0.55))
+                    .frame(width: 1),
+                alignment: .trailing
+            )
+            .overlay(
+                Rectangle()
+                    .fill(theme.codeBorder.opacity(0.55))
+                    .frame(height: 1),
+                alignment: .bottom
+            )
     }
 
     @ViewBuilder

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${ROOT_DIR}"
+
+APP_NAME="AIChat"
+APP_DISPLAY_NAME="Humlex"
+APP_BUNDLE=".build/${APP_DISPLAY_NAME}.app"
+CONTENTS_DIR="${APP_BUNDLE}/Contents"
+MACOS_DIR="${CONTENTS_DIR}/MacOS"
+RESOURCES_DIR="${CONTENTS_DIR}/Resources"
+FRAMEWORKS_DIR="${CONTENTS_DIR}/Frameworks"
+ICON_SOURCE="assets/icon@1024px.png"
+UPDATER_CONFIG="config/updater.conf"
+
+WATCH_MODE=false
+OPEN_AFTER_BUILD=true
+QUIT_BEFORE_OPEN=true
+CLEAN_BUILD=false
+BUILD_CONFIGURATION="debug"
+
+if [[ -t 1 ]]; then
+    C_RESET="\033[0m"
+    C_DIM="\033[2m"
+    C_BOLD="\033[1m"
+    C_BLUE="\033[34m"
+    C_GREEN="\033[32m"
+    C_YELLOW="\033[33m"
+    C_RED="\033[31m"
+else
+    C_RESET=""
+    C_DIM=""
+    C_BOLD=""
+    C_BLUE=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_RED=""
+fi
+
+timestamp() {
+    date +"%H:%M:%S"
+}
+
+log_info() {
+    printf "%b[%s] [INFO] %s%b\n" "${C_BLUE}" "$(timestamp)" "$*" "${C_RESET}"
+}
+
+log_ok() {
+    printf "%b[%s] [ OK ] %s%b\n" "${C_GREEN}" "$(timestamp)" "$*" "${C_RESET}"
+}
+
+log_warn() {
+    printf "%b[%s] [WARN] %s%b\n" "${C_YELLOW}" "$(timestamp)" "$*" "${C_RESET}"
+}
+
+log_error() {
+    printf "%b[%s] [FAIL] %s%b\n" "${C_RED}" "$(timestamp)" "$*" "${C_RESET}" >&2
+}
+
+print_header() {
+    printf "%b\n" "${C_BOLD}----------------------------------------${C_RESET}"
+    printf "%b\n" "${C_BOLD} Humlex Dev Runner${C_RESET}"
+    printf "%b\n" "${C_BOLD}----------------------------------------${C_RESET}"
+    printf "%b\n" "${C_DIM}root: ${ROOT_DIR}${C_RESET}"
+}
+
+print_config() {
+    printf "%b\n" "${C_BOLD}Configuration${C_RESET}"
+    printf "  build:   %s\n" "${BUILD_CONFIGURATION}"
+    printf "  watch:   %s\n" "${WATCH_MODE}"
+    printf "  clean:   %s\n" "${CLEAN_BUILD}"
+    printf "  open:    %s\n" "${OPEN_AFTER_BUILD}"
+    printf "  quit:    %s\n" "${QUIT_BEFORE_OPEN}"
+}
+
+on_error() {
+    local code="$1"
+    log_error "Script failed (exit ${code})."
+}
+
+trap 'on_error "$?"' ERR
+
+usage() {
+    cat <<'EOF'
+Usage: ./dev.sh [options]
+
+Options:
+  --watch           Rebuild/relaunch on file changes (requires fswatch)
+  --no-open         Build app bundle only, do not open it
+  --no-quit         Do not quit existing Humlex before launch
+  --clean           Run swift package clean before build
+  --release         Build release configuration
+  -h, --help        Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --watch)
+            WATCH_MODE=true
+            ;;
+        --no-open)
+            OPEN_AFTER_BUILD=false
+            ;;
+        --no-quit)
+            QUIT_BEFORE_OPEN=false
+            ;;
+        --clean)
+            CLEAN_BUILD=true
+            ;;
+        --release)
+            BUILD_CONFIGURATION="release"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [[ ! -f "${UPDATER_CONFIG}" ]]; then
+    log_error "Missing updater config at ${UPDATER_CONFIG}"
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "${UPDATER_CONFIG}"
+
+if [[ -z "${SU_FEED_URL:-}" || -z "${SU_PUBLIC_ED_KEY:-}" ]]; then
+    log_error "SU_FEED_URL and SU_PUBLIC_ED_KEY must be set in ${UPDATER_CONFIG}"
+    exit 1
+fi
+
+swift_flags=("-c" "${BUILD_CONFIGURATION}")
+
+quit_existing_app() {
+    if ! ${QUIT_BEFORE_OPEN}; then
+        return
+    fi
+
+    log_info "Closing running ${APP_DISPLAY_NAME} instance (if any)..."
+    osascript -e "tell application \"${APP_DISPLAY_NAME}\" to quit" >/dev/null 2>&1 || true
+    pkill -x "${APP_DISPLAY_NAME}" >/dev/null 2>&1 || true
+}
+
+build_bundle() {
+    local start_time
+    local end_time
+    local duration
+    local bin_path
+    local sparkle_fw
+    local iconset_dir
+
+    start_time=$(date +%s)
+
+    if ${CLEAN_BUILD}; then
+        log_info "Cleaning package..."
+        swift package clean
+        log_ok "Clean complete"
+    fi
+
+    log_info "Building ${APP_DISPLAY_NAME} (${BUILD_CONFIGURATION})..."
+    swift build "${swift_flags[@]}"
+
+    bin_path="$(swift build "${swift_flags[@]}" --show-bin-path)/${APP_NAME}"
+    if [[ ! -f "${bin_path}" ]]; then
+        log_error "Build output not found at ${bin_path}"
+        exit 1
+    fi
+
+    mkdir -p "${MACOS_DIR}" "${RESOURCES_DIR}" "${FRAMEWORKS_DIR}"
+    cp "${bin_path}" "${MACOS_DIR}/${APP_DISPLAY_NAME}"
+
+    sparkle_fw="$(dirname "${bin_path}")/Sparkle.framework"
+    if [[ -d "${sparkle_fw}" ]]; then
+        log_info "Embedding Sparkle.framework..."
+        rm -rf "${FRAMEWORKS_DIR}/Sparkle.framework"
+        cp -R "${sparkle_fw}" "${FRAMEWORKS_DIR}/"
+        install_name_tool -add_rpath "@executable_path/../Frameworks" "${MACOS_DIR}/${APP_DISPLAY_NAME}" 2>/dev/null || true
+        codesign --force --sign - "${MACOS_DIR}/${APP_DISPLAY_NAME}"
+        log_ok "Sparkle embedded"
+    else
+        log_warn "Sparkle.framework not found, continuing without it"
+    fi
+
+    if [[ -f "${ICON_SOURCE}" ]]; then
+        iconset_dir="$(mktemp -d)/AppIcon.iconset"
+        mkdir -p "${iconset_dir}"
+
+        sips -z 16   16   "${ICON_SOURCE}" --out "${iconset_dir}/icon_16x16.png"      >/dev/null
+        sips -z 32   32   "${ICON_SOURCE}" --out "${iconset_dir}/icon_16x16@2x.png"   >/dev/null
+        sips -z 32   32   "${ICON_SOURCE}" --out "${iconset_dir}/icon_32x32.png"      >/dev/null
+        sips -z 64   64   "${ICON_SOURCE}" --out "${iconset_dir}/icon_32x32@2x.png"   >/dev/null
+        sips -z 128  128  "${ICON_SOURCE}" --out "${iconset_dir}/icon_128x128.png"    >/dev/null
+        sips -z 256  256  "${ICON_SOURCE}" --out "${iconset_dir}/icon_128x128@2x.png" >/dev/null
+        sips -z 256  256  "${ICON_SOURCE}" --out "${iconset_dir}/icon_256x256.png"    >/dev/null
+        sips -z 512  512  "${ICON_SOURCE}" --out "${iconset_dir}/icon_256x256@2x.png" >/dev/null
+        sips -z 512  512  "${ICON_SOURCE}" --out "${iconset_dir}/icon_512x512.png"    >/dev/null
+        sips -z 1024 1024 "${ICON_SOURCE}" --out "${iconset_dir}/icon_512x512@2x.png" >/dev/null
+
+        iconutil -c icns "${iconset_dir}" -o "${RESOURCES_DIR}/AppIcon.icns"
+        rm -rf "$(dirname "${iconset_dir}")"
+    fi
+
+    cat > "${CONTENTS_DIR}/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>${APP_DISPLAY_NAME}</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.local.humlex</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>${APP_DISPLAY_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.0.0-dev</string>
+    <key>CFBundleVersion</key>
+    <string>0.0.0-dev</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>SUFeedURL</key>
+    <string>${SU_FEED_URL}</string>
+    <key>SUPublicEDKey</key>
+    <string>${SU_PUBLIC_ED_KEY}</string>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+
+    end_time=$(date +%s)
+    duration=$((end_time - start_time))
+    log_ok "Build complete in ${duration}s"
+}
+
+launch_app() {
+    if ! ${OPEN_AFTER_BUILD}; then
+        return
+    fi
+
+    quit_existing_app
+    log_info "Opening ${APP_BUNDLE}..."
+    open "${APP_BUNDLE}"
+    log_ok "Launched ${APP_DISPLAY_NAME}"
+}
+
+build_and_maybe_launch() {
+    build_bundle
+    launch_app
+}
+
+if ${WATCH_MODE}; then
+    if ! command -v fswatch >/dev/null 2>&1; then
+        log_error "--watch requires fswatch. Install with: brew install fswatch"
+        exit 1
+    fi
+
+    print_header
+    print_config
+    build_and_maybe_launch
+    log_info "Watching for changes (Ctrl+C to stop)..."
+    while true; do
+        changes="$(fswatch -1 -r --exclude '(^|/)\.git/' --exclude '(^|/)\.build/' "${ROOT_DIR}")"
+        first_change="${changes%%$'\n'*}"
+        first_change="${first_change#${ROOT_DIR}/}"
+        log_info "Change detected: ${first_change}"
+        log_info "Rebuilding..."
+        build_and_maybe_launch
+    done
+else
+    print_header
+    print_config
+    build_and_maybe_launch
+fi


### PR DESCRIPTION
- Introduce `dev.sh` for building and launching the app with watch mode, Sparkle framework embedding, and automatic icon generation
- Update Kimi adapter to use custom message type with reasoning content support for assistant tool call messages
- Rename "Kimi" provider to "Kimi for Coding" for clarity
- Move "New Chat" button from toolbar to sidebar header with label
- Remove timestamps from user message rows; auto-expand tool results on errors or denied operations
- Add table block parsing stub in MarkdownView
- Fix import ordering and access levels in AI_ChatApp.swift