### PR TITLE
 Add MCP server status dropdown to chat composer

### DIFF
--- a/Views/ChatComposerView.swift
+++ b/Views/ChatComposerView.swift
@@ -40,6 +40,7 @@ struct ChatComposerView: View {
     @State private var previousDraft = ""
     @State private var isShowingModelPicker = false
     @State private var modelSearchText = ""
+    @State private var isShowingMCPDropdown = false
 
     private var selectedModelLabel: String {
         models.first(where: { $0.reference == selectedModelReference })?.displayName ?? "Select model"
@@ -112,6 +113,28 @@ struct ChatComposerView: View {
                             searchText: $modelSearchText,
                             isPresented: $isShowingModelPicker
                         )
+                    }
+
+                    // MCP Server dropdown
+                    Button {
+                        isShowingMCPDropdown.toggle()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "server.rack")
+                                .font(.system(size: 11))
+                            Text("MCP")
+                                .font(.system(size: 12, weight: .medium))
+                            Image(systemName: "chevron.down")
+                                .font(.system(size: 10, weight: .semibold))
+                        }
+                        .foregroundStyle(theme.textSecondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(theme.hoverBackground, in: Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .popover(isPresented: $isShowingMCPDropdown, arrowEdge: .top) {
+                        MCPServerDropdown(isPresented: $isShowingMCPDropdown)
                     }
 
                     Button {

--- a/Views/MCPServerDropdown.swift
+++ b/Views/MCPServerDropdown.swift
@@ -1,0 +1,167 @@
+//
+//  MCPServerDropdown.swift
+//  AI Chat
+//
+//  Created by Humlex on 2/11/26.
+//
+
+import SwiftUI
+
+struct MCPServerDropdown: View {
+    @Binding var isPresented: Bool
+    @ObservedObject var mcpManager = MCPManager.shared
+
+    @Environment(\.appTheme) private var theme
+
+    private var hasServers: Bool {
+        !mcpManager.serverStatuses.isEmpty
+    }
+
+    private var connectedCount: Int {
+        mcpManager.serverStatuses.values.filter { status in
+            if case .connected = status { return true }
+            return false
+        }.count
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            theme.divider.frame(height: 1)
+            serverList
+        }
+        .frame(width: 280, height: min(CGFloat(mcpManager.serverStatuses.count * 44 + 60), 320))
+        .background(theme.surfaceBackground)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "server.rack")
+                .font(.system(size: 12))
+                .foregroundStyle(theme.textSecondary)
+
+            Text("MCP Servers")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(theme.textPrimary)
+
+            Spacer()
+
+            if hasServers {
+                Text("\(connectedCount)/\(mcpManager.serverStatuses.count) connected")
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.textSecondary)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    private var serverList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if !hasServers {
+                    emptyState
+                } else {
+                    ForEach(Array(mcpManager.serverStatuses.keys.sorted()), id: \.self) { serverName in
+                        if let status = mcpManager.serverStatuses[serverName] {
+                            serverRow(name: serverName, status: status)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "server.rack")
+                .font(.system(size: 24))
+                .foregroundStyle(theme.textTertiary)
+            Text("No MCP servers configured")
+                .font(.system(size: 12))
+                .foregroundStyle(theme.textSecondary)
+            Text("Add servers in Settings → MCP")
+                .font(.system(size: 11))
+                .foregroundStyle(theme.textTertiary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+    }
+
+    private func serverRow(name: String, status: MCPManager.ServerStatus) -> some View {
+        HStack(spacing: 10) {
+            statusIndicator(status)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(.system(size: 13))
+                    .foregroundStyle(theme.textPrimary)
+                    .lineLimit(1)
+
+                Text(statusLabel(status))
+                    .font(.system(size: 11))
+                    .foregroundStyle(statusColor(status).opacity(0.8))
+            }
+
+            Spacer()
+
+            if case .error = status {
+                Button {
+                    Task {
+                        await mcpManager.reconnect(serverName: name)
+                    }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 11))
+                        .foregroundStyle(theme.accent)
+                }
+                .buttonStyle(.plain)
+                .help("Reconnect server")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.clear)
+        )
+        .contentShape(Rectangle())
+    }
+
+    private func statusIndicator(_ status: MCPManager.ServerStatus) -> some View {
+        Circle()
+            .fill(statusColor(status))
+            .frame(width: 8, height: 8)
+            .overlay(
+                Circle()
+                    .stroke(statusColor(status).opacity(0.3), lineWidth: 2)
+            )
+    }
+
+    private func statusColor(_ status: MCPManager.ServerStatus) -> Color {
+        switch status {
+        case .connected:
+            return .green
+        case .connecting:
+            return .orange
+        case .error:
+            return .red
+        case .disconnected:
+            return .gray
+        }
+    }
+
+    private func statusLabel(_ status: MCPManager.ServerStatus) -> String {
+        switch status {
+        case .connected:
+            return "Connected"
+        case .connecting:
+            return "Connecting..."
+        case .error(let msg):
+            return msg.count > 30 ? String(msg.prefix(30)) + "..." : msg
+        case .disconnected:
+            return "Disconnected"
+        }
+    }
+}


### PR DESCRIPTION
- Adds a new MCP server dropdown popover accessible from the chat composer
- Displays real-time connection status for all configured MCP servers
- Shows connected/total count in header, with color-coded status indicators
- Includes reconnect button for servers in error state
- Provides empty state guidance when no servers are configured